### PR TITLE
main: remove pinned version on tested-oses module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,7 @@ locals {
 
 module "dcos-tested-oses" {
   source  = "dcos-terraform/tested-oses/gcp"
-  version = "~> 0.1.0"
+  version = "~> 0.1"
 
   providers = {
     google = "google"


### PR DESCRIPTION
We need to start removing the pinned version of 0.1.0 as its causing issues with forward updates on the patch versions.