### PR TITLE
breaking change: allow prereqs for instance termination/redeployment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -101,6 +101,11 @@ resource "google_compute_instance" "instances" {
 }
 
 resource "null_resource" "instance-prereq" {
+  # Changes to any instance of the cluster requires re-provisioning
+  triggers {
+    current_ec2_instance_id = "${element(google_compute_instance.instances.*.id, count.index)}"
+  }
+
   # If the user supplies an AMI or user_data we expect the prerequisites are met.
   count = "${var.image == "" ? var.num_instances : 0}"
 

--- a/main.tf
+++ b/main.tf
@@ -103,7 +103,7 @@ resource "google_compute_instance" "instances" {
 resource "null_resource" "instance-prereq" {
   # Changes to any instance of the cluster requires re-provisioning
   triggers {
-    current_ec2_instance_id = "${element(google_compute_instance.instances.*.id, count.index)}"
+    current_instance_id = "${element(google_compute_instance.instances.*.id, count.index)}"
   }
 
   # If the user supplies an AMI or user_data we expect the prerequisites are met.


### PR DESCRIPTION
When instances are terminated from an external source, this change allows the prereqs to be rerun