### PR TITLE
main/output: removing deprecated nat_ip for gcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Creates generic instances for DC/OS nodes
 ```hcl
 module "masters" {
   source  = "dcos-terraform/instance/gcp"
-  version = "~> 0.1.0"
+  version = "~> 0.2.0"
 
   providers = {
     google = "google"
@@ -68,7 +68,7 @@ module "masters" {
 | instance_subnetwork_name | Instance Subnetwork Name |
 | instances_self_link | List of instance self links |
 | machine_type | Instance Type |
-| name_prefix | Cluster Name |
+| name_prefix | Name Prefix |
 | num_instances | How many instances should be created |
 | prereq_id | Prereq id used for dependency |
 | private_ips | List of private ip addresses created by this module |

--- a/main.tf
+++ b/main.tf
@@ -105,7 +105,7 @@ resource "null_resource" "instance-prereq" {
   count = "${var.image == "" ? var.num_instances : 0}"
 
   connection {
-    host        = "${element(google_compute_instance.instances.*.network_interface.0.access_config.0.assigned_nat_ip, count.index)}"
+    host        = "${element(google_compute_instance.instances.*.network_interface.0.access_config.0.nat_ip, count.index)}"
     user        = "${coalesce(var.ssh_user, module.dcos-tested-oses.user)}"
     private_key = "${local.private_key}"
     agent       = "${local.agent}"

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@
  *```hcl
  * module "masters" {
  *   source  = "dcos-terraform/instance/gcp"
- *   version = "~> 0.1.0"
+ *   version = "~> 0.2.0"
  *
  *   providers = {
  *     google = "google"
@@ -32,7 +32,9 @@
  *```
  */
 
-provider "google" {}
+provider "google" {
+  version = "~> 2.0"
+}
 
 data "google_client_config" "current" {}
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,7 +4,7 @@ output "num_instances" {
 }
 
 output "name_prefix" {
-  description = "Cluster Name"
+  description = "Name Prefix"
   value       = "${var.cluster_name}"
 }
 
@@ -75,7 +75,7 @@ output "private_ips" {
 
 output "public_ips" {
   description = "List of public ip addresses created by this module"
-  value       = ["${google_compute_instance.instances.*.network_interface.0.access_config.0.assigned_nat_ip}"]
+  value       = ["${google_compute_instance.instances.*.network_interface.0.access_config.0.nat_ip}"]
 }
 
 output "instances_self_link" {


### PR DESCRIPTION
The terraform provider google was updated to 2.x with this update the labels where moved to its google-beta provider. As we rely on this labels we either have to stick with an old version or have to use the google-beta provider.

https://jira.mesosphere.com/browse/DCOS-48802