### PR TITLE
Add support for plaintext public ssh key

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -87,7 +87,7 @@ resource "google_compute_instance" "instances" {
 
   metadata = {
     user-data = "${var.user_data}"
-    sshKeys   = "${coalesce(var.ssh_user, module.dcos-tested-oses.user)}:${file(var.public_ssh_key)}"
+    sshKeys   = "${coalesce(var.ssh_user, module.dcos-tested-oses.user)}:${var.public_ssh_key}"
   }
 
   lifecycle {


### PR DESCRIPTION
Part of a series of PRs to support plaintext public ssh key. This is a breaking change for anyone using this module directly and passing in a file path for `public_ssh_key`. The README is ambiguous about what the value should be. The GCP master, bootstrap, private and public agent modules don't really care. They just pass through whatever the infrastructure module sends in. So the biggest change is in the infrastructure module. 

Addresses https://github.com/dcos-terraform/terraform-gcp-instance/issues/9